### PR TITLE
Add PDF signing exam app

### DIFF
--- a/exam/README.md
+++ b/exam/README.md
@@ -1,0 +1,29 @@
+# Exam PDF Signer
+
+This folder contains an independent web application for uploading and signing PDF files.
+
+## Structure
+- `server/` – Node.js mock signing server.
+- `client/` – React application.
+
+Both parts have their own `package.json` files and can be installed independently.
+
+## Usage
+1. Install server dependencies and start the mock server:
+   ```bash
+   cd server
+   npm install
+   node index.js
+   ```
+   The server listens on port `4000` by default.
+
+2. In another terminal, install and start the React app:
+   ```bash
+   cd ../client
+   npm install
+   npm start
+   ```
+
+3. Open `http://localhost:3000` in your browser.
+
+Upload a PDF via drag-and-drop or file picker. The server will return a "signed" PDF with a text overlay. The signed document is displayed in-app with options to download or upload a new file.

--- a/exam/client/package.json
+++ b/exam/client/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "exam-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-scripts": "5.0.1",
+    "react-dropzone": "^14.2.3",
+    "react-toastify": "^11.0.5"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --watchAll=false"
+  }
+}

--- a/exam/client/public/index.html
+++ b/exam/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PDF Signer</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/exam/client/src/App.css
+++ b/exam/client/src/App.css
@@ -1,0 +1,48 @@
+.container {
+  max-width: 800px;
+  margin: auto;
+  padding: 1rem;
+  text-align: center;
+}
+
+.dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  border: 2px dashed #777;
+  border-radius: 8px;
+  background: #fff;
+  color: #555;
+  cursor: pointer;
+}
+.dropzone p { margin: 0.5rem 0; }
+.format { font-size: 0.9rem; color: #888; }
+
+.loading { margin-top: 1rem; }
+
+.viewer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.viewer iframe {
+  width: 100%;
+  min-height: 60vh;
+  border: 1px solid #ccc;
+}
+.actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+@media (max-width: 600px) {
+  .dropzone {
+    padding: 1rem;
+  }
+  .viewer iframe {
+    min-height: 50vh;
+  }
+}

--- a/exam/client/src/App.js
+++ b/exam/client/src/App.js
@@ -1,0 +1,79 @@
+import React, { useState, useCallback } from 'react';
+import { useDropzone } from 'react-dropzone';
+import { toast, ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import './App.css';
+
+function App() {
+  const [pdfUrl, setPdfUrl] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const onDrop = useCallback(async (acceptedFiles, fileRejections) => {
+    if (fileRejections.length > 0) {
+      toast.error('Unsupported file type. Please upload a PDF.');
+      return;
+    }
+
+    const file = acceptedFiles[0];
+    if (!file) return;
+
+    setLoading(true);
+    try {
+      const formData = new FormData();
+      formData.append('pdf', file);
+      const res = await fetch('http://localhost:4000/sign', {
+        method: 'POST',
+        body: formData,
+      });
+      if (!res.ok) throw new Error('Server error');
+      const blob = await res.blob();
+      setPdfUrl(URL.createObjectURL(blob));
+      toast.success('PDF signed and ready to view!');
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to sign PDF.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: { 'application/pdf': [] },
+    multiple: false,
+  });
+
+  const reset = () => setPdfUrl(null);
+
+  return (
+    <div className="container">
+      <h1>PDF Upload & Sign</h1>
+      {!pdfUrl && (
+        <div {...getRootProps({ className: 'dropzone' })}>
+          <input {...getInputProps()} />
+          {isDragActive ? (
+            <p>Drop the PDF here...</p>
+          ) : (
+            <p>Drag & drop a PDF here, or click to select</p>
+          )}
+          <p className="format">Supported format: PDF (.pdf) files only.</p>
+        </div>
+      )}
+
+      {loading && <p className="loading">Uploading and signing...</p>}
+
+      {pdfUrl && (
+        <div className="viewer">
+          <iframe title="signed-pdf" src={pdfUrl} />
+          <div className="actions">
+            <a href={pdfUrl} download="signed.pdf">Download PDF</a>
+            <button onClick={reset}>Re-upload</button>
+          </div>
+        </div>
+      )}
+      <ToastContainer position="bottom-right" />
+    </div>
+  );
+}
+
+export default App;

--- a/exam/client/src/index.css
+++ b/exam/client/src/index.css
@@ -1,0 +1,9 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f9f9f9;
+}
+
+#root {
+  padding: 1rem;
+}

--- a/exam/client/src/index.js
+++ b/exam/client/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/exam/server/index.js
+++ b/exam/server/index.js
@@ -1,0 +1,43 @@
+import express from 'express';
+import cors from 'cors';
+import multer from 'multer';
+import { PDFDocument, rgb } from 'pdf-lib';
+
+const app = express();
+const upload = multer({ storage: multer.memoryStorage() });
+
+app.use(cors());
+
+// POST /sign - accept PDF and return signed version
+app.post('/sign', upload.single('pdf'), async (req, res) => {
+  try {
+    if (!req.file || req.file.mimetype !== 'application/pdf') {
+      return res.status(400).json({ error: 'Invalid file type' });
+    }
+
+    // Load PDF and add a mock signature text
+    const pdfDoc = await PDFDocument.load(req.file.buffer);
+    const pages = pdfDoc.getPages();
+    const firstPage = pages[0];
+    const { width, height } = firstPage.getSize();
+    firstPage.drawText('Signed by Mock Server', {
+      x: 50,
+      y: height - 50,
+      size: 18,
+      color: rgb(1, 0, 0),
+    });
+
+    const signedPdfBytes = await pdfDoc.save();
+
+    res.setHeader('Content-Type', 'application/pdf');
+    res.send(Buffer.from(signedPdfBytes));
+  } catch (err) {
+    console.error('Sign error', err);
+    res.status(500).json({ error: 'Failed to sign PDF' });
+  }
+});
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => {
+  console.log(`Mock signing server running on port ${PORT}`);
+});

--- a/exam/server/package.json
+++ b/exam/server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "exam-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "multer": "^1.4.5-lts.1",
+    "pdf-lib": "^1.17.1"
+  }
+}


### PR DESCRIPTION
## Summary
- create `exam` folder containing an independent PDF signer project
- implement mock Express signing server
- build React uploader app with drag & drop support, toasters, and responsive viewer

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887a8df2be88322a29904026fd72b99